### PR TITLE
Ship v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.0.5 (2018-09-23)
+==================
+
+* [New Feature] Add `athena.preview` operator
+* [New Feature] Add `preview` option for `athena.query` operator. This option is true, then run `athena.preview` operator after `athena.query` is executed.
+* [Enhancement] Add `athena.remove_metadata` operator for internal use. `athena.query` execute this when `keep_metadata` is false after `athena.preview` operator because `athena.preview` requires matadata.
+
 0.0.4 (2018-08-13)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.0.4
+      - pro.civitaspo:digdag-operator-athena:0.0.5
   athena:
     auth_method: profile
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.0.4'
+version = '0.0.5'
 
 def digdagVersion = '0.9.27'
 def awsSdkVersion = "1.11.372"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.0.4
+      - pro.civitaspo:digdag-operator-athena:0.0.5
   athena:
     auth_method: profile
     query:


### PR DESCRIPTION
* [New Feature] Add `athena.preview` operator
* [New Feature] Add `preview` option for `athena.query` operator. This option is true, then run `athena.preview` operator after `athena.query` is executed.
* [Enhancement] Add `athena.remove_metadata` operator for internal use. `athena.query` execute this when `keep_metadata` is false after `athena.preview` operator because `athena.preview` requires matadata.