### PR TITLE
Rel/v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.1.0 (2018-10-20)
+==================
+
+* [New Feature] Add `athena.ctas>` operator
+* [Breaking Change] Remove **keep_metadata** and **save_mode** option from athena.query operator.
+* [Change] Change **output** option in `athena.query` to not required
+* [Deprecated] Change **output** option in `athena.query` to deprecated
+
 0.0.6 (2018-10-14)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,21 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.0.6
+      - pro.civitaspo:digdag-operator-athena:0.1.0
   athena:
     auth_method: profile
 
 +step1:
   athena.query>: template.sql
-  output: s3://mybucket/prefix/
 
 +step2:
   echo>: ${athena.last_query}
 
++stap3:
+  athena.ctas>:
+  select_query: template.sql
+  table: hoge
+  output: s3://mybucket/prefix/
 ```
 
 # Configuration

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.0.6'
+version = '0.1.0'
 
 def digdagVersion = '0.9.27'
 def awsSdkVersion = "1.11.372"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.0.6
+      - pro.civitaspo:digdag-operator-athena:0.1.0
   athena:
     auth_method: profile
     value: 5


### PR DESCRIPTION
* [New Feature] Add `athena.ctas>` operator
* [Breaking Change] Remove **keep_metadata** and **save_mode** option from athena.query operator.
* [Change] Change **output** option in `athena.query` to not required
* [Deprecated] Change **output** option in `athena.query` to deprecated