### PR TITLE
[athena.ctas] Skip removing objects if removable targets do not exist

### DIFF
--- a/src/main/scala/pro/civitaspo/digdag/plugin/athena/operator/AthenaCtasOperator.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/athena/operator/AthenaCtasOperator.scala
@@ -111,6 +111,7 @@ class AthenaCtasOperator(operatorName: String, context: OperatorContext, systemC
   protected def rmObjects(location: String): Unit = {
     val uri: AmazonS3URI = AmazonS3URI(location)
     val keys: Seq[String] = withS3(_.listObjectsV2(uri.getBucket, uri.getKey)).getObjectSummaries.asScala.map(_.getKey)
+    if (keys.isEmpty) return
     val r: DeleteObjectsResult = withS3(_.deleteObjects(new DeleteObjectsRequest(uri.getBucket).withKeys(keys: _*)))
     r.getDeletedObjects.asScala.foreach(o => logger.info(s"Deleted: s3://${uri.getBucket}/${o.getKey}"))
   }


### PR DESCRIPTION
* [Fix] `athena.ctas>` Skip removing objects if removable targets do not exist.