### PR TITLE
Change token generation logic to make all queries new execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Define the below options on properties (which is indicated by `-c`, `--config`).
 ### Options
 
 - **athena.query>**: The SQL query statements or file to be executed. You can use digdag's template engine like `${...}` in the SQL query. (string, required)
-- **token_prefix**: Prefix for `ClientRequestToken` that a unique case-sensitive string used to ensure the request to create the query is idempotent (executes only once). On this plugin, the token is composed like `${token_prefix}-${session_uuid}-${hash value of query}`. (string, default: `"digdag-athena"`)
+- **token_prefix**: Prefix for `ClientRequestToken` that a unique case-sensitive string used to ensure the request to create the query is idempotent (executes only once). On this plugin, the token is composed like `${token_prefix}-${session_uuid}-${hash value of query}-${random string}`. (string, default: `"digdag-athena"`)
 - **database**: The name of the database. (string, optional)
 - **output**: The location in Amazon S3 where your query results are stored, such as `"s3://path/to/query/"`. For more information, see [Queries and Query Result Files](https://docs.aws.amazon.com/athena/latest/ug/querying.html). (string, default: `"s3://aws-athena-query-results-${AWS_ACCOUNT_ID}-<AWS_REGION>"`)
 - **timeout**: Specify timeout period. (`DurationParam`, default: `"10m"`)
@@ -151,7 +151,7 @@ Define the below options on properties (which is indicated by `-c`, `--config`).
   - `"error_if_exists"`: Raise error if the distination table or location exists.
   - `"ignore"`: Skip CTAS query if the distination table or location exists.
   - `"overwrite"`: Drop the distination table and remove objects before executing CTAS. This operation is not atomic.
-- **token_prefix**: Prefix for `ClientRequestToken` that a unique case-sensitive string used to ensure the request to create the query is idempotent (executes only once). On this plugin, the token is composed like `${token_prefix}-${session_uuid}-${hash value of query}`. (string, default: `"digdag-athena-ctas"`)
+- **token_prefix**: Prefix for `ClientRequestToken` that a unique case-sensitive string used to ensure the request to create the query is idempotent (executes only once). On this plugin, the token is composed like `${token_prefix}-${session_uuid}-${hash value of query}-${radom string}`. (string, default: `"digdag-athena-ctas"`)
 - **timeout**: Specify timeout period. (`DurationParam`, default: `"10m"`)
 
 ### Output Parameters

--- a/src/main/scala/pro/civitaspo/digdag/plugin/athena/operator/AthenaQueryOperator.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/athena/operator/AthenaQueryOperator.scala
@@ -22,7 +22,7 @@ import io.digdag.spi.{OperatorContext, TaskResult, TemplateEngine}
 import io.digdag.util.DurationParam
 import pro.civitaspo.digdag.plugin.athena.wrapper.{NotRetryableException, ParamInGiveup, ParamInRetry, RetryableException, RetryExecutorWrapper}
 
-import scala.util.Try
+import scala.util.{Random, Try}
 import scala.util.hashing.MurmurHash3
 
 class AthenaQueryOperator(operatorName: String, context: OperatorContext, systemConfig: Config, templateEngine: TemplateEngine)
@@ -80,7 +80,8 @@ class AthenaQueryOperator(operatorName: String, context: OperatorContext, system
 
   protected lazy val clientRequestToken: String = {
     val queryHash: Int = MurmurHash3.bytesHash(query.getBytes(UTF_8), 0)
-    s"$tokenPrefix-$sessionUuid-$queryHash"
+    val random: String = Random.alphanumeric.take(5).mkString
+    s"$tokenPrefix-$sessionUuid-$queryHash-$random"
   }
 
   protected lazy val output: AmazonS3URI = {


### PR DESCRIPTION
- [Fix] All queries are executed as a new query, even if the same query is executed in the same digdag session.