### PR TITLE
Ship v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.1.3 (2018-12-07)
+==================
+
+* [Fix] All queries are executed as a new query, even if the same query is executed in the same digdag session.
+
 0.1.2 (2018-12-07)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.1.2
+      - pro.civitaspo:digdag-operator-athena:0.1.3
   athena:
     auth_method: profile
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.1.2'
+version = '0.1.3'
 
 def digdagVersion = '0.9.27'
 def awsSdkVersion = "1.11.372"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.1.2
+      - pro.civitaspo:digdag-operator-athena:0.1.3
   athena:
     auth_method: profile
     value: 5


### PR DESCRIPTION
* [Fix] All queries are executed as a new query, even if the same query is executed in the same digdag session.