### PR TITLE
Ship v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.2.1 (2019-07-16)
+==================
+
+* [Enhancement] Add `format`, `compression` and `field_delimiter` options to `athena.apas>` operator. If not set, these are detected automatically.
+
 0.2.0 (2019-07-16)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.2.0
+      - pro.civitaspo:digdag-operator-athena:0.2.1
   athena:
     auth_method: profile
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.2.0'
+version = '0.2.1'
 
 def digdagVersion = '0.9.37'
 def awsSdkVersion = "1.11.587"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.2.0
+      - pro.civitaspo:digdag-operator-athena:0.2.1
   athena:
     auth_method: profile
     value: 5


### PR DESCRIPTION
* [Enhancement] Add `format`, `compression` and `field_delimiter` options to `athena.apas>` operator. If not set, these are detected automatically.