### PR TITLE
Ship v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.2.2 (2019-07-19)
+==================
+
+* [Enhancement] Use scala-logging for logging instead of using slf4j directly
+* [Enhancement] Use workgroup default output location for athena query result output location.
+* [Change - `athena.ctas>`] Introduce `location` option and `output` option become deprecated.
+
+
 0.2.1 (2019-07-16)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.2.1
+      - pro.civitaspo:digdag-operator-athena:0.2.2
   athena:
     auth_method: profile
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.2.1'
+version = '0.2.2'
 
 def digdagVersion = '0.9.37'
 def awsSdkVersion = "1.11.587"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.2.1
+      - pro.civitaspo:digdag-operator-athena:0.2.2
   athena:
     auth_method: profile
     value: 5


### PR DESCRIPTION
* [Enhancement] Use scala-logging for logging instead of using slf4j directly
* [Enhancement] Use workgroup default output location for athena query result output location.
* [Change - `athena.ctas>`] Introduce `location` option and `output` option become deprecated.