### PR TITLE
Ship v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+0.3.0 (2019-07-30)
+==================
+
+* [Breaking change -- `athena.ctas>`] Remove output option which has been deprecated since v0.2.2.
+* [Breaking change -- `athena.ctas>`] Remove select_query option which has been deprecated since v0.2.0.
+* [Note -- `athena.ctas>`] Replace com.google.common.base.Optional -> scala.Option.
+* [Enhancement -- `athena.ctas>`] Add `/` as suffix if location option does not have.
+* [Change  -- `athena.ctas>`] Use `athena.drop_table>` operator instead of `athena.query>` operator when deleting the table.
+    * This change is to reduce the number of query executions.
+    * `athena.ctas>` operator depends on Glue privileges by this change.
+* [Note -- `athena.ctas>`] Use `default` database if not database option specified.
+
 0.2.5 (2019-07-29)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.2.5
+      - pro.civitaspo:digdag-operator-athena:0.3.0
   athena:
     auth_method: profile
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.2.5'
+version = '0.3.0'
 
 def digdagVersion = '0.9.37'
 def awsSdkVersion = "1.11.587"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.2.5
+      - pro.civitaspo:digdag-operator-athena:0.3.0
   athena:
     auth_method: profile
     value: 5


### PR DESCRIPTION
* [Breaking change -- `athena.ctas>`] Remove output option which has been deprecated since v0.2.2.
* [Breaking change -- `athena.ctas>`] Remove select_query option which has been deprecated since v0.2.0.
* [Note -- `athena.ctas>`] Replace com.google.common.base.Optional -> scala.Option.
* [Enhancement -- `athena.ctas>`] Add `/` as suffix if location option does not have.
* [Change  -- `athena.ctas>`] Use `athena.drop_table>` operator instead of `athena.query>` operator when deleting the table.
    * This change is to reduce the number of query executions.
    * `athena.ctas>` operator depends on Glue privileges by this change.
* [Note -- `athena.ctas>`] Use `default` database if not database option specified.