### PR TITLE
Ship v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.3.1 (2019-08-05)
+==================
+
+* [Fix -- `athena.ctas>`] When using `save_mode: overwrite`, delete the specified table and location, not the table location that the data catalog has.
+* [New featuere -- `athena.drop_table_multi>`] `protect` option.
+
 0.3.0 (2019-07-30)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.3.0
+      - pro.civitaspo:digdag-operator-athena:0.3.1
   athena:
     auth_method: profile
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.3.0'
+version = '0.3.1'
 
 def digdagVersion = '0.9.37'
 def awsSdkVersion = "1.11.587"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.3.0
+      - pro.civitaspo:digdag-operator-athena:0.3.1
   athena:
     auth_method: profile
     value: 5


### PR DESCRIPTION
* [Fix -- `athena.ctas>`] When using `save_mode: overwrite`, delete the specified table and location, not the table location that the data catalog has.
* [New featuere -- `athena.drop_table_multi>`] `protect` option.