### PR TITLE
Ship v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.4.0 (2019-10-20)
+==================
+* [Enhancement] Update dependencies: aws-sdk 1.11.587  -> 1.11.653,  digdag 0.9.37  -> 0.9.39
+* [Fix] Fix README: athena.query> preview option is false by default
+* [New feature] Support auth_method: web_identity_token
+
 0.3.2 (2019-08-06)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.3.2
+      - pro.civitaspo:digdag-operator-athena:0.4.0
   athena:
     auth_method: profile
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.3.2'
+version = '0.4.0'
 
 def digdagVersion = '0.9.39'
 def awsSdkVersion = "1.11.653"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-athena:0.3.2
+      - pro.civitaspo:digdag-operator-athena:0.4.0
   athena:
     auth_method: profile
     value: 5


### PR DESCRIPTION
* [Enhancement] Update dependencies: aws-sdk 1.11.587  -> 1.11.653,  digdag 0.9.37  -> 0.9.39
* [Fix] Fix README: athena.query> preview option is false by default
* [New feature] Support auth_method: web_identity_token